### PR TITLE
feat: a simple package web for handler responses added

### DIFF
--- a/pkg/web/error.go
+++ b/pkg/web/error.go
@@ -1,0 +1,36 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type errorResponse struct {
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}
+
+func Error(w http.ResponseWriter, statusCode int, message string) {
+	// default status code
+	defaultStatusCode := http.StatusInternalServerError
+	// check if status code is valid
+	if statusCode > 299 && statusCode < 600 {
+		defaultStatusCode = statusCode
+	}
+
+	// response
+	body := errorResponse{
+		Status:  http.StatusText(defaultStatusCode),
+		Message: message,
+	}
+	bytes, err := json.Marshal(body)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// write response
+	w.WriteHeader(defaultStatusCode)
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(bytes)
+}

--- a/pkg/web/response.go
+++ b/pkg/web/response.go
@@ -1,1 +1,32 @@
 package web
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// JSON writes json response
+func JSON(w http.ResponseWriter, code int, body any) {
+	// check body
+	if body == nil {
+		w.WriteHeader(code)
+		return
+	}
+
+	// marshal body
+	bytes, err := json.Marshal(body)
+	if err != nil {
+		// default error
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// set header
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+	// set status code
+	w.WriteHeader(code)
+
+	// write body
+	w.Write(bytes)
+}


### PR DESCRIPTION
This pull request introduces utility functions for handling HTTP responses in JSON format within the `pkg/web` package. The changes include adding a generic JSON response writer and a standardized error response handler.

### HTTP response utilities:

* [`pkg/web/error.go`]: Added an `Error` function to send standardized JSON error responses. This function validates the provided status code, constructs a JSON error body with a status and message, and sets appropriate headers.
* [`pkg/web/response.go`]: Added a `JSON` function to send generic JSON responses. This function handles `nil` bodies, marshals the response body into JSON, and sets the appropriate headers and status code.